### PR TITLE
Support for more display types. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,12 @@
-Additional components to use esphome with a M5StickC.  
+Extending esphome-m5stickc by airy/geiseri base to support more displays.
+Hampered by lack of displays for testing.
+The .yaml config now includes a  `model: redtab,greentab,blacktab, ...`. 
+
+Only `blacktabex` is tested. The other have `setup()` sequences derived from the Ur display code (Adafruit) or
+the projects this was forked from.
+
+To quote:
+
 Mostly a work in progress.  
 Copy the components to a `custom_components` directory next to your .yaml configuration file.
 

--- a/components/st7735/__init__.py
+++ b/components/st7735/__init__.py
@@ -1,3 +1,0 @@
-import esphome.codegen as cg
-
-st7735_ns = cg.esphome_ns.namespace('st7735')

--- a/components/st7735/display.py
+++ b/components/st7735/display.py
@@ -2,28 +2,46 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome import pins
 from esphome.components import display, spi
-from esphome.const import CONF_ID, CONF_LAMBDA
-from esphome.const import CONF_DC_PIN, CONF_CS_PIN, CONF_ID, CONF_LAMBDA, CONF_PAGES
-from esphome.const import CONF_EXTERNAL_VCC, CONF_LAMBDA, CONF_MODEL, CONF_RESET_PIN, \
-    CONF_BRIGHTNESS
-from . import st7735_ns
+from esphome.const import CONF_ID, CONF_LAMBDA, CONF_DC_PIN, CONF_CS_PIN, CONF_MODEL
+from esphome.const import CONF_RESET_PIN, CONF_BRIGHTNESS
 
 DEPENDENCIES = ['spi']
 
+st7735_ns = cg.esphome_ns.namespace('st7735')
+
 ST7735 = st7735_ns.class_('ST7735', cg.PollingComponent, spi.SPIDevice, display.DisplayBuffer)
 ST7735Ref = ST7735.operator('ref')
+ST7735Redtab = st7735_ns.class_('ST7735Redtab', ST7735)
+ST7735Greentab = st7735_ns.class_('ST7735Greentab', ST7735)
+ST7735Blacktab = st7735_ns.class_('ST7735Blacktab', ST7735)
+ST7735Greentab_144 = st7735_ns.class_('ST7735Greentab_144', ST7735)
+ST7735Mini_160_80 = st7735_ns.class_('ST7735Mini_160_80', ST7735)
+ST7735MStickC = st7735_ns.class_('ST7735M5StickC', ST7735)
+  
+MODELS = {
+    'blacktabex': ST7735,
+    'redtab': ST7735Redtab,
+    'greentab': ST7735Greentab,
+    'blacktab': ST7735Blacktab,
+    'greentab_144': ST7735Greentab_144,
+    'mini_160_80': ST7735Mini_160_80,
+    'm5stickc': ST7735MStickC,
+}
+
 
 CONFIG_SCHEMA = display.FULL_DISPLAY_SCHEMA.extend({
     cv.GenerateID(): cv.declare_id(ST7735),
+    cv.Required(CONF_MODEL): cv.one_of(*MODELS, lower=True),
     cv.Required(CONF_RESET_PIN): pins.gpio_output_pin_schema,
     cv.Required(CONF_DC_PIN): pins.gpio_output_pin_schema,
     cv.Required(CONF_CS_PIN): pins.gpio_output_pin_schema,
     cv.Optional(CONF_BRIGHTNESS, default=1.0): cv.percentage,
 }).extend(cv.polling_component_schema('1s')).extend(spi.spi_device_schema())
 
-
 def to_code(config):
-    var = cg.new_Pvariable(config[CONF_ID])
+    model = MODELS[config[CONF_MODEL]]
+    rhs = model.new()
+    var = cg.Pvariable(config[CONF_ID], rhs, model)
     yield cg.register_component(var, config)
     yield spi.register_spi_device(var, config)
 

--- a/components/st7735/st7735.h
+++ b/components/st7735/st7735.h
@@ -80,6 +80,11 @@
 #define ST7735_NVMSET		0xFC      // NVM setting
 #define ST7735_PROMACT		0xFE      // Program action
 
+#define ST7735_TFTWIDTH_128 128  // for 1.44 and mini
+#define ST7735_TFTWIDTH_80 80    // for mini
+#define ST7735_TFTHEIGHT_128 128 // for 1.44" display
+#define ST7735_TFTHEIGHT_160 160 // for 1.8" and mini display
+
 namespace esphome {
 namespace st7735 {
 
@@ -144,13 +149,15 @@ class ST7735 : public PollingComponent, public display::DisplayBuffer,
   float get_setup_priority() const override;
   void update() override;
   void loop() override;
-  
+
   void write_display_data();
   
  protected:
   GPIOPin *dc_pin_;
   GPIOPin *reset_pin_{nullptr};
-  
+
+  void commonSetup();
+  void commonCompleteSetup();
   void displayInit(const uint8_t *addr);
   void sendcommand(uint8_t cmd, const uint8_t* dataBytes, uint8_t numDataBytes);
   void senddata(const uint8_t* dataBytes, uint8_t numDataBytes);
@@ -166,7 +173,74 @@ class ST7735 : public PollingComponent, public display::DisplayBuffer,
 
   int get_height_internal() override;
   int get_width_internal() override;
+  int get_xoffset_internal() ;
+  int get_yoffset_internal() ;
   size_t get_buffer_length_();
+};
+
+enum ST7735Model {
+  BLACKTAB_128_160 = 0,  // The one I'm developing for
+  REDTAB = 1,            // Adafruit red
+  GREENTAB = 2,          // Adafruit green
+  BLACKTAB = 3,          // Adafruit black
+  GREENTAB_144 = 4,
+  MINI_160_80 = 5,
+  HALLOWING = 6,
+  M5STICKC = 7,
+};
+
+class ST7735Blacktab_128_160 : public ST7735 {
+ public:
+  void setup() override;
+  int get_width_internal() override;
+  int get_height_internal() override;
+  int get_xoffset_internal();
+  int get_yoffset_internal();
+};
+
+class ST7735Blacktab : public ST7735 {
+ public:
+  void setup() override;
+  int get_width_internal() override;
+  int get_height_internal() override;
+  int get_xoffset_internal();
+  int get_yoffset_internal();
+};
+
+class ST7735Mini_160_80 : public ST7735 {
+ public:
+  void setup() override;
+  int get_width_internal() override;
+  int get_height_internal() override;
+  int get_xoffset_internal();
+  int get_yoffset_internal();
+};
+
+class ST7735M5StickC : public ST7735 {
+ public:
+  void setup() override;
+  int get_width_internal() override;
+  int get_height_internal() override;
+  int get_xoffset_internal();
+  int get_yoffset_internal();
+};
+
+class ST7735Redtab : public ST7735 {
+ public:
+  void setup() override;
+  int get_width_internal() override;
+  int get_height_internal() override;
+  int get_xoffset_internal();
+  int get_yoffset_internal();
+};
+
+class ST7735Greentab : public ST7735 {
+ public:
+  void setup() override;
+  int get_width_internal() override;
+  int get_height_internal() override;
+  int get_xoffset_internal();
+  int get_yoffset_internal();
 };
 
 

--- a/sample-config/m5stickc.yaml
+++ b/sample-config/m5stickc.yaml
@@ -117,6 +117,7 @@ font:
 # builtin 80x160 TFT
 display:
   - platform: st7735
+    model: m5stickc
     cs_pin: GPIO5
     dc_pin: GPIO23
     reset_pin: GPIO18


### PR DESCRIPTION
Superceded by events -- ESPHome just merged a PR for a much more complete ST7735 driver. 


I created this fork to support parameterized display types. I can't test most of them.

The code compiles, and supports the cheap TFT I got from AliExpress.

I'd be happy to have this go upstream, and if the displays all work, I think it might be ready for a pull request to Esphome.
